### PR TITLE
Use the database and uri when VCAP_SERVICES env var is provided

### DIFF
--- a/blog/app.py
+++ b/blog/app.py
@@ -44,20 +44,15 @@ def post():
 def connect_db():
     if 'VCAP_SERVICES' in os.environ:
         vcap_json = json.loads(os.getenv('VCAP_SERVICES'))
-        mongo_host = vcap_json['mongodb'][0]['credentials']['host']
-        mongo_username = vcap_json['mongodb'][0]['credentials']['username']
-        mongo_password = vcap_json['mongodb'][0]['credentials']['password']
-        mongo_port = vcap_json['mongodb'][0]['credentials']['port']
-        mongo_uri = vcap_json['mongodb'][0]['credentials']['uri']
-        conn = pymongo.MongoClient(mongo_host,
-                                  username=mongo_username,
-                                  password=mongo_password,
-                                  authSource='admin',
-                                  authMechanism='SCRAM-SHA-1')
+        credentials = vcap_json['mongodb'][0]['credentials']
+        mongo_uri = credentials['uri']
+        mongo_database = credentials['database']
     else:
         mongo_uri = 'mongodb://localhost:27017'
-        conn = pymongo.MongoClient(mongo_uri)
-    return conn['blog']
+        mongo_database = 'blog'
+
+    conn = pymongo.MongoClient(mongo_uri)
+    return conn[mongo_database]
 
 if __name__ == "__main__":
     # NOTE: debug True breaks PyDev debugger


### PR DESCRIPTION
## Description

When `VCAP_SERVICES` is provided to the app, it should use the `database` passed under the credentials object.

Also, changing this to use the URI instead of the separate bits.

## Test plan

Part of the mongodb minibroker brain tests on SCF repo.